### PR TITLE
Added "ClientContainer" type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -302,6 +302,7 @@ export interface AdminUserProfile {
     privileges: AdminPrivileges;
     first_name: string;
     last_name: string;
+    phone_primary?: number;
     features?: AdminFeatureSelection | null;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -493,6 +493,7 @@ export interface NewPendingAampReport {
     address?: string;
     description: string;
     chat_messages?: number[];
+    source_message?: number;
     bot_generated?: boolean;
     media?: string[];
     point?: Point;

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Polygon, MultiPolygon, Point } from "geojson";
+import { MultiPolygon, Point, Polygon } from "geojson";
 import { AdminPrivileges } from "./adminPrivileges";
 
 export type reportType =
@@ -647,7 +647,12 @@ export const AampUpdateMinimumPrivileges: {
     description: AdminPrivileges.MANAGER,
     point: AdminPrivileges.MANAGER,
     fields: AdminPrivileges.MANAGER,
-    archived: AdminPrivileges.MANAGER
+    archived: AdminPrivileges.MANAGER,
+    username: AdminPrivileges.MANAGER,
+    first_name: AdminPrivileges.MANAGER,
+    last_name: AdminPrivileges.MANAGER,
+    chat_messages: AdminPrivileges.MANAGER,
+    source_message: AdminPrivileges.MANAGER
 };
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -485,14 +485,15 @@ export interface AampReportFields {
 
 export interface NewPendingAampReport {
     form_id: number;
-    first_name: string;
-    last_name: string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
     email?: string;
     date_time: Date;
     address?: string;
     description: string;
-    media: string[];
-    point: Point;
+    media?: string[];
+    point?: Point;
     fields: AampReportFields;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -489,9 +489,10 @@ export interface NewPendingAampReport {
     first_name?: string;
     last_name?: string;
     email?: string;
-    date_time: Date;
+    date_time?: Date;
     address?: string;
     description: string;
+    chat_messages?: number[];
     media?: string[];
     point?: Point;
     fields: AampReportFields;
@@ -661,7 +662,8 @@ export interface TelegramMessage {
 export interface TelegramChat {
     id: number,
     type: string,
-    title: string
+    title: string,
+    form_id: number
 }
 
 export interface TelegramUser {

--- a/index.ts
+++ b/index.ts
@@ -302,7 +302,7 @@ export interface AdminUserProfile {
     privileges: AdminPrivileges;
     first_name: string;
     last_name: string;
-    phone_primary?: number;
+    phone_primary?: string;
     features?: AdminFeatureSelection | null;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -493,6 +493,7 @@ export interface NewPendingAampReport {
     address?: string;
     description: string;
     chat_messages?: number[];
+    bot_generated?: boolean;
     media?: string[];
     point?: Point;
     fields: AampReportFields;

--- a/index.ts
+++ b/index.ts
@@ -319,6 +319,11 @@ export interface Client {
     domain?: string | null;
 }
 
+export interface ClientContainers {
+    client_id: number;
+    containers: string[];
+}
+
 export interface DisplayClient extends Client {
     type: "Client";
     incidents: number,

--- a/index.ts
+++ b/index.ts
@@ -647,6 +647,30 @@ export const AampUpdateMinimumPrivileges: {
 };
 
 /**
+ * Interfaces corresponding to Message and Chat objects from Telegram's Bot API
+ */
+export interface TelegramMessage {
+    message_id: number,
+    text: string,
+    from: TelegramUser,
+    chat: TelegramChat,
+    date: number
+}
+
+export interface TelegramChat {
+    id: number,
+    type: string,
+    title: string
+}
+
+export interface TelegramUser {
+    id: number,
+    username: string,
+    first_name: string,
+    last_name: string
+}
+
+/**
  * Public Report to be added to DB
  */
 export interface PublicReportToInsert {

--- a/index.ts
+++ b/index.ts
@@ -691,8 +691,8 @@ export interface TelegramUser {
  */
 export interface PublicReportToInsert {
     created_at?: Date;
-    date_time?: Date;
-    point?: Point;
+    date_time: Date;
+    point: Point;
     address?: string;
     report_type: reportType;
     source_type: PublicReportSourceType;

--- a/index.ts
+++ b/index.ts
@@ -651,19 +651,32 @@ export const AampUpdateMinimumPrivileges: {
 /**
  * Interfaces corresponding to Message and Chat objects from Telegram's Bot API
  */
+
+/**
+ * Telegram message as represented in the DB
+ */
 export interface TelegramMessage {
     message_id: number,
     text: string,
-    from: TelegramUser,
-    chat: TelegramChat,
+    chat_id: number,
+    user_id: number,
     date: number
 }
+
+/**
+ * Telegram message with user and chat objects embedded.
+ * This is the format that Telegram sends its messages in
+ */
+export interface TelegramMessageDetails extends Omit<TelegramMessage, "chat_id" | "user_id"> {
+    from: TelegramUser,
+    chat: TelegramChat,
+};
 
 export interface TelegramChat {
     id: number,
     type: string,
     title: string,
-    form_id: number
+    form_id?: number
 }
 
 export interface TelegramUser {
@@ -678,8 +691,8 @@ export interface TelegramUser {
  */
 export interface PublicReportToInsert {
     created_at?: Date;
-    date_time: Date;
-    point: Point;
+    date_time?: Date;
+    point?: Point;
     address?: string;
     report_type: reportType;
     source_type: PublicReportSourceType;


### PR DESCRIPTION
Made a type for an object which holds two fields- the client ID (number) and the containers array (string[]) that denotes which containers the new user has access to. Used to enforce type safety for the input object into the ModifyClientContainers API route.