### PR TITLE
T-169/Added types + routes for edit history tracking feature

### DIFF
--- a/aamp.ts
+++ b/aamp.ts
@@ -74,6 +74,7 @@ export interface CountedForm extends NewForm {
     domains: string[];
     immediate_public: boolean;
     count: number;
+    chats: string[];
 }
 
 export interface PendingAampReportToInsert extends NewPendingAampReport {
@@ -130,11 +131,45 @@ export const AampUpdateMinimumPrivileges: {
  * Telegram message as represented in the DB
  */
 export interface TelegramMessage {
-    message_id: number,
-    text: string,
-    chat_id: number,
-    user_id: number,
-    date: number
+  message_id: number;
+  text: string;
+  chat_id: number;
+  user_id: number;
+  date: number;
+  media?: string | undefined;
+  type: string;
+  photo?: TelegramPhotoSize[];
+  video?: TelegramVideo;
+  animation?: any;
+  audio?: any;
+  document?: any;
+  sticker?: any;
+  contact?: any;
+  game?: any;
+  poll?: any;
+  venue?: any;
+  location?: any;
+  invoice?: any;
+}
+
+export interface TelegramPhotoSize {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+export interface TelegramVideo {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  duration: number;
+  thumb?: TelegramPhotoSize;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
 }
 
 /**

--- a/aamp.ts
+++ b/aamp.ts
@@ -92,11 +92,28 @@ export interface PendingAampReport extends PendingAampReportToInsert {
     archived: boolean;
     public_report_id?: number | null;
     created_at: Date;
+    changes: string[];
 }
 
-export type PendingAampReportUpdate = Partial<Omit<PendingAampReport, "fields">> & {
+export type PendingAampReportUpdate = Partial<Omit<PendingAampReport, "fields" | "changes">> & {
     id: number;
     fields?: Partial<AampReportFields>;
+    changes: string[];
+    identifier: string;
+};
+
+export interface editHistory {
+    payload: {
+        aamp_report_type?: string,
+        description?: string
+        aggressor?: string,
+        victim?: string, 
+        address?: string,
+        date_time?: string,
+    },
+    timestamp: string,
+    admin_user_id?: number |  null,
+    user_id?: number | null
 };
 
 /**

--- a/aamp.ts
+++ b/aamp.ts
@@ -99,7 +99,6 @@ export type PendingAampReportUpdate = Partial<Omit<PendingAampReport, "fields" |
     id: number;
     fields?: Partial<AampReportFields>;
     changes: string[];
-    identifier: string;
 };
 
 export interface editHistory {

--- a/admin.ts
+++ b/admin.ts
@@ -49,6 +49,9 @@ export interface Log {
     client_id?: number;
     admin_user_id?: number;
     route: string;
+    report_id?: number;
+    payload?: object;
+    edits_index: string;
 }
 
 export interface ClientCreation {

--- a/admin.ts
+++ b/admin.ts
@@ -40,6 +40,7 @@ export interface NewAdminUser {
     password: string | undefined;
     privileges: AdminPrivileges | undefined;
     features?: AdminFeatureSelection | undefined;
+    phone_primary?: string;
 }
 
 export interface Log {

--- a/admin.ts
+++ b/admin.ts
@@ -51,7 +51,6 @@ export interface Log {
     route: string;
     report_id?: number;
     payload?: object;
-    edits_index: string;
 }
 
 export interface ClientCreation {

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -172,3 +172,21 @@ export const getFullTranscriptMessages = (report_id: number): Promise<TelegramMe
   url: "/aamp/getFullTranscriptMessages",
   data: { report_id },
 });
+
+export const updatePendingReport = (data: PendingAampReportUpdate) : Promise<void> => request<void>(true, {
+    method: "POST",
+    url: "/aamp/updatePendingReport",
+    data: data
+});
+
+export const getPendingReportEdits = (logIdentifier: string) : Promise<editHistory[]> => request<editHistory[]>(true, {
+    method: "POST",
+    url: "/aamp/getPendingReportEdits",
+    data: { logIdentifier }
+})
+
+export const getUserProfileByID = (user_id: number) : Promise<UserProfile> => request<UserProfile>(true, {
+    method: "POST",
+    url: "/admin/getUserProfile",
+    data: { user_id }
+})

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -15,7 +15,11 @@ import {
 } from "../admin";
 import { Container, DefaultRegion } from "../geo";
 import { ClientDisplayData, TeamUpdate, UserProfile, UserUpdate } from "../client";
+<<<<<<< HEAD
 import { CountedForm, PendingAampReport, TelegramChat, TelegramMessageDetails } from "../aamp";
+=======
+import {CountedForm, editHistory, PendingAampReport, PendingAampReportUpdate} from "../aamp";
+>>>>>>> c5da974... added types + routes for edit history tracking feature
 
 export const getClientDisplayData = (): Promise<ClientDisplayData> => request<ClientDisplayData>(true, {
     method: "GET",

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -15,7 +15,7 @@ import {
 } from "../admin";
 import { Container, DefaultRegion } from "../geo";
 import { ClientDisplayData, TeamUpdate, UserProfile, UserUpdate } from "../client";
-import {CountedForm, PendingAampReport} from "../aamp";
+import { CountedForm, PendingAampReport, TelegramChat, TelegramMessageDetails } from "../aamp";
 
 export const getClientDisplayData = (): Promise<ClientDisplayData> => request<ClientDisplayData>(true, {
     method: "GET",
@@ -144,15 +144,31 @@ export const registerChat = (data: ChatFormLink): Promise<void> => request<void>
     data: data
 })
 
+export const getChats = () : Promise<TelegramChat[]> => request<TelegramChat[]>(true, {
+    method: "GET",
+    url: "/aamp/getChats",
+});
+
 export const getCountedForms = () : Promise<{[container_name: string]: CountedForm[]}> => request<{ [container_name: string]: CountedForm[] }>(true, {
-        method: "GET",
-        url: "/aamp/getFormsAndCounts",
+    method: "GET",
+    url: "/aamp/getFormsAndCounts",
 });
 
 export const getAampReportsByFormId = (form: number) : Promise<PendingAampReport[]> => request<PendingAampReport[]>(true, {
     method: "POST",
     url: "/aamp/getPendingReportsByFormId",
-    data: {
-        requestedForm: form
-    }
+    data: { requestedForm: form }
+});
+
+export const getReportChatMessages = (report_id: number, before: number, after: number): Promise<TelegramMessageDetails[]> =>
+request<TelegramMessageDetails[]>(true, {
+  method: "POST",
+  url: "/aamp/getReportChatMessages",
+  data: { report_id, before, after },
+});
+
+export const getFullTranscriptMessages = (report_id: number): Promise<TelegramMessageDetails[]> => request<TelegramMessageDetails[]>(true, {
+  method: "POST",
+  url: "/aamp/getFullTranscriptMessages",
+  data: { report_id },
 });

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -179,10 +179,10 @@ export const updatePendingReport = (data: PendingAampReportUpdate) : Promise<voi
     data: data
 });
 
-export const getPendingReportEdits = (logIdentifier: string) : Promise<editHistory[]> => request<editHistory[]>(true, {
+export const getPendingReportEdits = (report_id: number) : Promise<editHistory[]> => request<editHistory[]>(true, {
     method: "POST",
     url: "/aamp/getPendingReportEdits",
-    data: { logIdentifier }
+    data: { report_id }
 })
 
 export const getUserProfileByID = (user_id: number) : Promise<UserProfile> => request<UserProfile>(true, {

--- a/api/client.ts
+++ b/api/client.ts
@@ -64,6 +64,12 @@ export const getClientUsers = (): Promise<UserProfile[]> =>
         url: "/client/getClientUsers"
     });
 
+export const getClientDevices = (): Promise<Device[]> =>
+    request<Device[]>(true, {
+        method: "get",
+        url: "/client/getClientDevices"
+    })
+
 export const createReport = (report: NewClientReport): Promise<void> =>
     request<void>(true, {
         method: "post",

--- a/auth.ts
+++ b/auth.ts
@@ -23,6 +23,19 @@ export interface Device {
     modified_at?: Date;
 }
 
+export interface DisplayDevice {
+    user_id: number;
+    client_id: number;
+    token: string | null;
+    device_type: DeviceType;
+    device_fingerprint: string;
+    point?: Point;
+    modified_at?: Date;
+    user_name?: string;
+    team_id?: number;
+    active_sos?: boolean;
+}
+
 export type DeviceType = "Web" | "Mobile";
 
 export interface DeviceSubscription {

--- a/client.ts
+++ b/client.ts
@@ -197,6 +197,7 @@ export interface UserFeatureSelection {
     forecastingMenu?: boolean | null;
     publicInsightsMenu?: boolean | null;
     newsfeedMenu?: boolean | null;
+    tracking?: boolean | null;
 }
 
 export interface PublicInsight {

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
             "optional": true
         },
         "@types/react": {
-            "version": "17.0.14",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
-            "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
+            "version": "17.0.15",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.15.tgz",
+            "integrity": "sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",


### PR DESCRIPTION
**Types Added/ Modified**
- Modified `PendingAampReportUpdate` interface to include a `changes` element which is a `string[]` that holds a record of all the fields which were modified as the middleware would have a much harder time figuring this out via backend communication. Also included an `identifier` field to hold the unique key used in the `logs` table to query as using the `report_id` is no longer viable.
- Added a new `EditHistory` interface to hold the blueprint for the object returned by the `getPendingReportEdits` route. This object includes the time at which the edit took place (`timestamp`), the fields which were edited (`payload`), and either the admin or user ID which modified the report. 
- Modified `Log` interface to account for new columns used in the "Logs" table

**Routes Added/ Modified to api/admin.ts**
- Added `getPendingReportEdits`: Route used to communicate a pending AAMP report's edit history from backend to frontend
- Added `getUserProfile`: Route used to communicate a user's information (for render purposes) after querying by `user_id`
- Modified `updatePendingReport`: Added data specificity along with input changes