### PR TITLE
Sayyant/t-376 types changes

### DIFF
--- a/admin.ts
+++ b/admin.ts
@@ -1,5 +1,5 @@
 import { Client, Profile, UserFeatureSelection} from "./client";
-import { GeoJsonGeometryTypes, MultiPolygon, Polygon } from "geojson";
+import { GeoJsonGeometryTypes, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon } from "geojson";
 import { ViewportBase } from "./geo";
 
 
@@ -135,7 +135,7 @@ export interface AssetType {
     category: string;
     relevant_event_types: string[];
     relevant_concerns: string[];
-    relevant_geographies: JSON;
+    relevant_geographies: string[];
     mobile: boolean;
 }
 
@@ -145,7 +145,7 @@ export interface Asset {
     client_id?: number;
     team_id?: number;
     description?: string;
-    geography?: GeoJsonGeometryTypes;
+    geography: Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon;
     operation_interval?: string;
     concerns?: AssetConcern[];
     relevant_event_types?: string[];
@@ -154,16 +154,21 @@ export interface Asset {
     erp_link?: string;
 }
 
-export interface consequence {
+export interface AssetToInsert extends Asset{
+    container_id: number[];
+    default_region_id: number[];
+}
+
+export interface Consequence {
     concern: AssetConcern;
     magnitude: number;
     timeframe: string;
 }
 
-export interface AssetRisk {
+export interface Risk {
     asset_id: number;
     concern: AssetConcern;
-    consequence: consequence;
+    consequence: Consequence;
     relevant_event_types: string[];
     risk_interval: string;
     created_at: Date;

--- a/admin.ts
+++ b/admin.ts
@@ -1,5 +1,5 @@
 import { Client, Profile, UserFeatureSelection} from "./client";
-import { MultiPolygon, Polygon } from "geojson";
+import { GeoJsonGeometryTypes, MultiPolygon, Polygon } from "geojson";
 import { ViewportBase } from "./geo";
 
 
@@ -8,6 +8,23 @@ import { ViewportBase } from "./geo";
  *  Defines types relevant to administrative users interacting directly with Jarvis API/Jarvis Admin.
  *
  */
+
+ export type AssetConcern = 
+ | "Profitability" 
+ | "Damage/Loss" 
+ | "Safety/Harm" 
+ | "Operations/Downtime" 
+ | "Reputation" 
+ | "Environmental";
+
+export const AllAssetConcerns : AssetConcern[] = [
+ "Profitability",
+ "Damage/Loss",
+ "Safety/Harm",
+ "Operations/Downtime",
+ "Reputation",
+ "Environmental"
+];
 
 export interface AdminUserProfile {
     id: number;
@@ -110,4 +127,49 @@ export interface NewTeamAdmin {
 export interface ChatFormLink {
     id: number; // Chat ID
     form_id: number;
+}
+
+export interface AssetType {
+    name: string;
+    description: string;
+    category: string;
+    relevant_event_types: string[];
+    relevant_concerns: string[];
+    relevant_geographies: JSON;
+    mobile: boolean;
+}
+
+export interface Asset {
+    name: string;
+    asset_type: string;
+    client_id?: number;
+    team_id?: number;
+    description?: string;
+    geography?: GeoJsonGeometryTypes;
+    operation_interval?: string;
+    concerns?: AssetConcern[];
+    relevant_event_types?: string[];
+    value?: number;
+    details?: JSON;
+    erp_link?: string;
+}
+
+export interface consequence {
+    concern: AssetConcern;
+    magnitude: number;
+    timeframe: string;
+}
+
+export interface AssetRisk {
+    asset_id: number;
+    concern: AssetConcern;
+    consequence: consequence;
+    relevant_event_types: string[];
+    risk_interval: string;
+    created_at: Date;
+    severity: number;
+    chance: number;
+    isObsolete: boolean;
+    updates: string[];
+    geography: JSON;
 }

--- a/geo.ts
+++ b/geo.ts
@@ -29,6 +29,11 @@ export interface GeoAttribution {
     default_region_id?: number;
 }
 
+export interface MultiDimGeoAttribution {
+    container_id_arr: number[];
+    default_region_id_arr: number[];
+}
+
 export interface ContainerResponseItem {
     containers: Container[];
     default_regions: DefaultRegion[];


### PR DESCRIPTION
Added types and interfaces according to the proposal as it is currently.

Other types:
`AssetToInsert`: An extension of the Asset type that also has `container_id` and `default_region_id` fields which are not inputs from the user but calculated by the route.
`MultiDimGeoAttribution`: Basically the `GeoAttribution` interface but capable of holding IDs in its fields
